### PR TITLE
Bump max-clause-count

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -514,4 +514,4 @@ Resources:
       CognitoOptions:
         Enabled: false
       AdvancedOptions:
-        "indices.query.bool.max_clause_count": "2048"
+        "indices.query.bool.max_clause_count": "4096"


### PR DESCRIPTION
- bump max_clause_count to allow silly complex queries while we wait for a more complete review of search requirements