### PR TITLE
fix: Allow updates without replacement

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -546,6 +546,8 @@ Resources:
     Type: AWS::OpenSearchService::Domain
     DeletionPolicy: Retain
     UpdateReplacePolicy: Retain
+    UpdatePolicy:
+      EnableVersionUpgrade: true
     Properties:
       AccessPolicies:
         Version: 2012-10-17


### PR DESCRIPTION
Sets `UpdatePolicy` so that a version upgrade of OpenSearch does not trigger a replacement of the cluster / domain. See https://docs.aws.amazon.com/AWSCloudFormation/latest/TemplateReference/aws-attribute-updatepolicy.html#cfn-attributes-updatepolicy-upgradeopensearchdomain for details.