### PR TITLE
build: Upgrade OpenSearch to 2.19

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -583,7 +583,7 @@ Resources:
           ZoneAwarenessEnabled: true
           ZoneAwarenessConfig:
             AvailabilityZoneCount: 3
-      EngineVersion: "OpenSearch_2.11"
+      EngineVersion: "OpenSearch_2.19"
       EBSOptions:
         EBSEnabled: true
         VolumeSize: 50


### PR DESCRIPTION
Upgrades the OpenSearch cluster to version 2.19. This should be tested extensively in `sws-dev` before we deploy the change to production.