### PR TITLE
build: Upgrade OpenSearch to 3.5

### DIFF
--- a/template.yaml
+++ b/template.yaml
@@ -583,7 +583,7 @@ Resources:
           ZoneAwarenessEnabled: true
           ZoneAwarenessConfig:
             AvailabilityZoneCount: 3
-      EngineVersion: "OpenSearch_2.19"
+      EngineVersion: "OpenSearch_3.5"
       EBSOptions:
         EBSEnabled: true
         VolumeSize: 50


### PR DESCRIPTION
Upgrades the OpenSearch cluster to `3.5`, which is the most recent version available in AWS (https://docs.aws.amazon.com/opensearch-service/latest/developerguide/what-is.html#choosing-version).