### PR TITLE
feat: Add OpenSearch UI dashboard

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,18 @@
 # search-workspace-service
 
 ![Alt text](resources/systemoverview.png)
+
+## OpenSearch UI dashboard
+
+The template creates an OpenSearch UI application (`AWS::OpenSearchService::Application`) with the OpenSearch domain as its data source.
+The application name is set by the `DashboardApplicationName` template parameter, which the master pipeline stack in `search-workspace-service-infrastructure` passes in per environment.
+Dashboard admin access is granted to all IAM principals that can access the application (`opensearchDashboards.dashboardAdmin.users: "*"`).
+
+Workspaces and dashboards are content inside the application, not AWS resources.
+There is no CloudFormation or AWS API support for them, so they are set up manually after the first deployment to a new environment:
+
+1. Open the application endpoint (found in the AWS console under OpenSearch Service, Central management, Applications).
+2. Create a workspace and connect it to the OpenSearch domain data source.
+3. Create dashboards in the workspace, or import existing ones (see below).
+
+To copy dashboards from another environment, export them there via Dashboards Management, Saved objects, Export (produces an NDJSON file), and import the file the same way in the target workspace.

--- a/template.yaml
+++ b/template.yaml
@@ -38,6 +38,13 @@ Parameters:
     Type: String
     Default: sws-auth-dev
     Description: The prefix for the Cognito domain that hosts the sign-up and sign-in pages for your application.
+  DashboardApplicationName:
+    Type: String
+    Default: sws-dev-dashboard
+    Description: Name of the OpenSearch UI dashboard application. Must be unique per account and region.
+    AllowedPattern: "[a-z][a-z0-9\\-]+"
+    MinLength: 3
+    MaxLength: 40
   CustomDomain:
     Type: String
     Description: Custom API to connect this lambda to
@@ -585,3 +592,16 @@ Resources:
         Enabled: false
       AdvancedOptions:
         "indices.query.bool.max_clause_count": "4096"
+
+  SWSDashboardApplication:
+    Type: AWS::OpenSearchService::Application
+    DeletionPolicy: Retain
+    UpdateReplacePolicy: Retain
+    Properties:
+      Name: !Ref DashboardApplicationName
+      DataSources:
+        - DataSourceArn: !GetAtt SWSOpenSearch.Arn
+          DataSourceDescription: SWS OpenSearch cluster
+      AppConfigs:
+        - Key: opensearchDashboards.dashboardAdmin.users
+          Value: "*"


### PR DESCRIPTION
Adds an OpenSearch UI application so that we can set up GUI dashboards for easier access. This allows authenticated users to run ad-hoc queries and see various analytics. See https://docs.aws.amazon.com/opensearch-service/latest/developerguide/application.html for more details.